### PR TITLE
Adding a proposed mapping between SQL database types and Rust.

### DIFF
--- a/tbd-core/Cargo.toml
+++ b/tbd-core/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 
 [dependencies]
+
+# Remove this again soon
+rusqlite = "0.13.0"

--- a/tbd-core/src/db_tool.rs
+++ b/tbd-core/src/db_tool.rs
@@ -1,0 +1,39 @@
+use mapping::User;
+use rusqlite::Connection;
+
+pub fn setup_db() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute(
+        "CREATE TABLE person (
+                  id              INTEGER PRIMARY KEY,
+                  name            TEXT NOT NULL,
+                  age             INTEGER
+                  )",
+        &[],
+    ).unwrap();
+    conn
+}
+
+pub fn create_dummy_data(conn: &Connection) {
+    let alice = User {
+        id: 0,
+        name: "Alice".to_string(),
+        age: 25,
+    };
+
+    let bob = User {
+        id: 0,
+        name: "Bob".to_string(),
+        age: 21,
+    };
+
+    conn.execute(
+        "INSERT INTO person (name, age) VALUES (?1, ?2)",
+        &[&alice.name, &alice.age],
+    ).unwrap();
+
+    conn.execute(
+        "INSERT INTO person (name, age) VALUES (?1, ?2)",
+        &[&bob.name, &bob.age],
+    ).unwrap();
+}

--- a/tbd-core/src/lib.rs
+++ b/tbd-core/src/lib.rs
@@ -1,7 +1,8 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+//! Shared code and data mapper
+
+extern crate rusqlite;
+
+mod mapping;
+mod db_tool;
+
+pub use mapping::test_this;

--- a/tbd-core/src/mapping.rs
+++ b/tbd-core/src/mapping.rs
@@ -1,0 +1,51 @@
+use db_tool;
+use rusqlite::Row;
+
+pub type SqlType<'row> = &'row Row<'row, 'row>;
+
+pub trait Mapping<'row, T>
+where
+    T: From<SqlType<'row>>,
+{
+    fn from_sql(s: SqlType<'row>) -> T {
+        s.into()
+    }
+}
+
+/// This is an in-memory representation of a user
+#[derive(Debug)]
+pub struct User {
+    pub id: i64,
+    pub name: String,
+    pub age: i8,
+}
+
+impl<'a> From<SqlType<'a>> for User {
+    fn from(s: SqlType) -> Self {
+        Self {
+            id: s.get(0),
+            name: s.get(1),
+            age: s.get(2),
+        }
+    }
+}
+
+/// Represent a mapping for a user
+pub struct UserMapping;
+impl<'row> Mapping<'row, User> for UserMapping {}
+
+pub fn test_this() {
+    let conn = db_tool::setup_db();
+    db_tool::create_dummy_data(&conn);
+
+    /* Query the database */
+    let mut stmt = conn.prepare("SELECT id, name, age FROM person").unwrap();
+
+    let users = stmt
+        .query_map(&[], |row| UserMapping::from_sql(row))
+        .unwrap()
+        .filter_map(|u| u.ok())
+        .collect::<Vec<User>>();
+
+    println!("{:#?}", users);
+}


### PR DESCRIPTION
This mapping assumes that writes are done via changesets and is
thus only one-directional. A `Mapping<T>` is generic for any struct
that wants to be mappable from SQL.

A user struct `Foo` would then need to implement `From<SqlType<'a> for Foo`
and a new mapping type which is `impl<'a> Mapping<'a, Foo> for FooMap {}` which
enables mapping via `FooMap::from_sql(&row)` where `row` is returned from
an sqlite query.

Ideally most of this code will be generated for the user, making manual
implementations for `From<?>` redundant.

`db_tool` adds some simple utilities to work with the database outside
of the example code and should be removed soon.

Actual code added is in [mapping.rs](https://github.com/berlinrs/tbd.rs/pull/2/files#diff-e97c229d9cc3feb4bbf110e85fcf178d)